### PR TITLE
Removes shortened URL for git.io deprecation

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-// Testing config MIT via https://git.io/vXCGg
+// Testing config MIT via https://github.com/vercel/react-keyframes/blob/main/test/index.js
 
 import test from 'ava'
 import React from 'react'


### PR DESCRIPTION
https://github.blog/changelog/2022-04-25-git-io-deprecation/